### PR TITLE
Update spinners.json

### DIFF
--- a/spinners/spinners.json
+++ b/spinners/spinners.json
@@ -5548,7 +5548,7 @@
     "name": "MUYI",
     "models": [
       {
-        "name": "Capsule",
+        "name": "Crucible",
         "file": "capsule.jpg",
         "price": "-1",
         "type": "Tri",


### PR DESCRIPTION
fixed Muyi Crucible name (was using "Capsule," the name of a Mackie spinner)